### PR TITLE
Kreas forviŝbutonon kaj plibonigas TAB-navigadon

### DIFF
--- a/facililo.css
+++ b/facililo.css
@@ -24,7 +24,7 @@ h1 {
 }
 
 #ekstera {
-    max-width: 30em;
+    max-width: 35em;
     margin-left: auto;
     margin-right: auto;
 }
@@ -34,12 +34,12 @@ h1 {
     background-color: white;
     border-radius: 50%;
     font-size: 200%;
-    vertical-align: text-bottom;
-    text-align: center;
     width: 1em;
     height: 1em;
+    padding: 0;
+    border: 0;
+    cursor: pointer;
     font-family: sans-serif;
-    text-decoration: none;
     box-shadow: 0.2em 0.2em 0.5em rgba(0, 0, 0, 0.9);
 }
 
@@ -94,6 +94,8 @@ textarea {
     float: right;
     cursor: pointer;
     font-size: 1.5em;
+    background-color: transparent;
+    border: 0;
 }
 
 #eksterhelpujo {

--- a/index.html
+++ b/index.html
@@ -47,16 +47,15 @@ laŭ la
 <a href="https://uea.facila.org/vortlisto/">vortolisto</a> de
 <a href="https://uea.facila.org/">uea.facila.org</a>.</label>
 
-<a role="button"
+<button
    data-bind="click: montruHelpon"
-   href=""
    id="helpobutono"
-   title="Pli da informoj">?</a>
+   title="Pli da informoj">?</button>
 
 <div id="eksterhelpujo" data-bind="visible: montrasHelpon">
 <div id="helpujo">
-<span title="Fermu la informfenestron" data-bind="click: malmontruHelpon"
-   class="fermilo" role="button">✗</span>
+<button title="Fermu la informfenestron" data-bind="click: malmontruHelpon"
+   class="fermilo">✗</button>
 <h2>Kio estas <em>Facililo</em>?</h2>
 
 <p>Per <em>Facililo</em> eblas kontroli, ĉu la enskribita teksto
@@ -175,8 +174,8 @@ pezajn kunmetaĵojn. Tial estas preferinde anstataŭigi ĝin per la
 
 <div data-bind="if: url">
 <div id="diskonigujo">
-<span title="Fermu la diskonigfenestreton" data-bind="click: nuliguURLn"
-   class="fermilo">✗</span>
+<button title="Fermu la diskonigfenestreton" data-bind="click: nuliguURLn"
+   class="fermilo">✗</button>
 <a data-bind="attr: { href: url }">Uzu tiun ĉi ligilon</a>
 aŭ kopiu la adreson:
 <input type="text" data-bind="value: url" id="urlujo">

--- a/index.html
+++ b/index.html
@@ -162,6 +162,7 @@ laŭ la
   <div id="regiloj" data-bind="if: $root.redaktebla">
   <label id="etikedoMaliksigu"><input type="checkbox" data-bind="checked: $root.maliksigu"> cx → ĉ</label>
   <button id="rekontrolu" type="button" data-bind="event: { click: $root.rekontrolu }">Rekontrolu</button>
+  <button id="forvisxu" type="button" onclick="malplenigasTekstujon()">Forviŝu</button>
   <button id="kopiu" type="button" data-clipboard-target="#montrujo">Kopiu</button>
   </div>
 
@@ -207,6 +208,13 @@ aŭ
 <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
 <script>
   new Clipboard('#kopiu');
+</script>
+
+<script>
+  function malplenigasTekstujon() {
+    let tekstujo = document.getElementById("tekstujo");
+    tekstujo.value = "";
+  }
 </script>
 
 <script src='facililo.js' charset='utf-8'></script>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,21 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 <h1>Facililo</h1>
 
+<div id="ekstera">
+<p>
+<label for="tekstujo">
+<span data-bind="if: redaktebla">Verku facilan tekston</span>
+<span data-bind="if: !redaktebla()">"Facila" teksto verkita</span>
+laŭ la
+<a href="https://uea.facila.org/vortlisto/">vortolisto</a> de
+<a href="https://uea.facila.org/">uea.facila.org</a>.</label>
+
+<a role="button"
+   data-bind="click: montruHelpon"
+   href=""
+   id="helpobutono"
+   title="Pli da informoj">?</a>
+
 <div id="eksterhelpujo" data-bind="visible: montrasHelpon">
 <div id="helpujo">
 <span title="Fermu la informfenestron" data-bind="click: malmontruHelpon"
@@ -130,21 +145,6 @@ pezajn kunmetaĵojn. Tial estas preferinde anstataŭigi ĝin per la
 
 </div>
 </div>
-
-<div id="ekstera">
-<p>
-<label for="tekstujo">
-<span data-bind="if: redaktebla">Verku facilan tekston</span>
-<span data-bind="if: !redaktebla()">"Facila" teksto verkita</span>
-laŭ la
-<a href="https://uea.facila.org/vortlisto/">vortolisto</a> de
-<a href="https://uea.facila.org/">uea.facila.org</a>.</label>
-
-<a role="button"
-   data-bind="click: montruHelpon"
-   href=""
-   id="helpobutono"
-   title="Pli da informoj">?</a>
 
 <p data-bind="if: redaktebla">
 <textarea

--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@ aŭ
   function malplenigasTekstujon() {
     let tekstujo = document.getElementById("tekstujo");
     tekstujo.value = "";
+    tekstujo.focus();
   }
 </script>
 


### PR DESCRIPTION
# Forviŝbutono
Forviŝbutono estis kreita. Ĝi estas kontrolita per normala JS.

Estis necesa iom plilarĝigi la paĝon por eviti ke la kontroliloj iru al la sekva linio. Indas prilabori reagan CSSn por eviti tiajn problemojn.

- #1 

# TAB-navigado
Estis kelkaj problemoj rilate al TAB-navigado en la programo, kioj povis ĝeni kelkajn uzantoj kaj malhelpi la uzon de homoj, kiu uzas ekranlegilon.

- Kiam oni malfermis la helpujon, la sekva TAB ne iris al tiu helpujo, sed al la tekstujo.
- La fermiloj de la helpujo kaj de diskonigujo ne estis alireblaj per TAB.

Ĉi tiu PR provas solvi tion per ŝanĝo de ordo inter la elementoj de la dokumento kaj butonigado de la fermiloj.